### PR TITLE
fix file not found error

### DIFF
--- a/src/mcp_server_ietf/server.py
+++ b/src/mcp_server_ietf/server.py
@@ -14,6 +14,7 @@ log_level = getattr(logging, default_log_level, logging.INFO)
 INDEX_URL = "https://www.rfc-editor.org/rfc-index.txt"
 RFC_URL_TEMPLATE = "https://www.rfc-editor.org/rfc/rfc{number}.txt"
 CACHE_DIR = os.path.expanduser("~/.cache/ietf-doc-server")
+os.makedirs(CACHE_DIR, exist_ok=True)
 DEFAULT_MAX_LINES = 200  # Default pagination limit
 
 log_file = os.path.join(CACHE_DIR, "mcp-server-ietf.log")


### PR DESCRIPTION
This PR ensures that the `CACHE_DIR` directory exists before attempting to create the log file.

I got the error below when initially starting the MCP server.
Since the `~/.cache/ietf-doc-server` does not initially exist, the log file could not be created successfully.

```
Traceback (most recent call last):
  File "/Users/octocat/src/github.com/eirob/mcp-server-ietf/.venv/bin/mcp-server-ietf", line 5, in <module>
    from mcp_server_ietf import main
  File "/Users/octocat/src/github.com/eirob/mcp-server-ietf/src/mcp_server_ietf/__init__.py", line 1, in <module>
    from . import server, rfc_parser
  File "/Users/octocat/src/github.com/eirob/mcp-server-ietf/src/mcp_server_ietf/server.py", line 25, in <module>
    logging.FileHandler(log_file),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1231, in __init__
    StreamHandler.__init__(self, self._open())
                                 ^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1263, in _open
    return open_func(self.baseFilename, self.mode,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Users/octocat/.cache/ietf-doc-server/mcp-server-ietf.log'
```